### PR TITLE
Adds classic command uniforms to loadout options

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/uniforms.dm
+++ b/code/modules/client/preference_setup/loadout/lists/uniforms.dm
@@ -212,3 +212,23 @@
 /datum/gear/uniform/frontier
 	display_name = "frontier clothes"
 	path = /obj/item/clothing/under/frontier
+
+/datum/gear/uniform/captain
+	display_name = "Commanding Officer's Classic Jumpsuit"
+	path = /obj/item/clothing/under/rank/captain
+
+/datum/gear/uniform/hop
+	display_name = "Executive Officer's Classic Jumpsuit"
+	path = /obj/item/clothing/under/rank/head_of_personnel
+
+/datum/gear/uniform/ce
+	display_name = "Chief Engineer's Classic Jumpsuit"
+	path = /obj/item/clothing/under/rank/chief_engineer
+/datum/gear/uniform/rd
+	display_name = "Research Director's Classic Jumpsuit"
+	path = /obj/item/clothing/under/rank/research_director
+
+/datum/gear/uniform/cmo
+	display_name = "Chief Medical Officer's Classic Jumpsuit"
+	path = /obj/item/clothing/under/rank/chief_medical_officer
+

--- a/maps/torch/loadout/_defines.dm
+++ b/maps/torch/loadout/_defines.dm
@@ -70,3 +70,15 @@
 #define NT_BRANCHES list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet)
 
 #define MILITARY_BRANCHES list(/datum/mil_branch/fleet, /datum/mil_branch/marine_corps)
+
+#define CAPTAIN_ROLE list(/datum/job/captain)
+
+#define HOP_ROLE list(/datum/job/hop)
+
+#define RD_ROLE list(/datum/job/rd)
+
+#define CMO_ROLE list(/datum/job/cmo)
+
+#define CE_ROLE list(/datum/job/chief_engineer)
+
+#define HOS_ROLE list(/datum/job/hos)

--- a/maps/torch/loadout/loadout_uniform.dm
+++ b/maps/torch/loadout/loadout_uniform.dm
@@ -1,6 +1,6 @@
 
 /datum/gear/uniform
-	allowed_branches = CIVILIAN_BRANCHES
+//	allowed_branches = CIVILIAN_BRANCHES
 
 /datum/gear/uniform/utility
 	display_name = "Contractor Utility Uniform"
@@ -81,3 +81,19 @@
 
 /datum/gear/uniform/corp_exec_jacket
 	allowed_roles = list(/datum/job/liaison, /datum/job/bodyguard)
+
+
+/datum/gear/uniform/captain
+	allowed_roles = CAPTAIN_ROLE
+
+/datum/gear/uniform/hop
+	allowed_roles = HOP_ROLE
+
+/datum/gear/uniform/ce
+	allowed_roles = CE_ROLE
+
+/datum/gear/uniform/rd
+	allowed_roles = RD_ROLE
+
+/datum/gear/uniform/cmo
+	allowed_roles = CMO_ROLE


### PR DESCRIPTION
The classic uniforms we all know.

:cl:
add: Classic Command uniforms to the loadout options.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->