### PR TITLE
Fixing the sign in bug, attempt one.

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -81,8 +81,9 @@ datum/preferences
 				return
 
 		stage = "load"
-		load_preferences()
-		load_character()
+		spawn(250) // Fixing the sign in bug, hopefully! Letting the slots have time to load.
+			load_preferences()
+			load_character()
 	catch(var/exception/E)
 		load_failed = "{[stage]} [E]"
 		throw E

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -25,6 +25,7 @@
 	verbs += /mob/proc/toggle_antag_pool
 
 /mob/new_player/proc/new_player_panel(force = FALSE)
+	sleep(500) // Fixing the sign in bug, hopefully! Letting the slot load before presenting.
 	if(!SScharacter_setup.initialized && !force)
 		return // Not ready yet.
 	var/output = list()


### PR DESCRIPTION
This tries to fix the sign-in character loading bug by pausing the character loading code, so that it cannot run ahead of itself.  Testing in production required, the sleep in the new_player.dm makes it so that it doesn't present a random character (despite actually having loaded it anyways).
:cl:
code: Character and pref loading delay, attempting to not let the code run ahead of itself.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->