### PR TITLE
Scale back Exoplanets, due heavy overhead implied by it.

### DIFF
--- a/config/torch_config.txt
+++ b/config/torch_config.txt
@@ -12,10 +12,10 @@ OVERMAP_Z 0
 OVERMAP_SIZE 50
 
 ## The number of event clouds - meteors, fish, etc - that will be generated on the overmap. Default 34
-OVERMAP_EVENT_AREAS 49
+OVERMAP_EVENT_AREAS 45
 
 ## The number of exoplanets to generate on the map. Warning: These have a significant runtime cost. Default 1
-NUM_EXOPLANETS 5
+NUM_EXOPLANETS 3
 
 ## The number of away sites to pick for the overmap. Default 3
 AWAY_SITE_BUDGET 7

--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -48,7 +48,8 @@
 
 	default_law_type = /datum/ai_laws/solgov
 	use_overmap = 1
-	num_exoplanets = 6
 
-	away_site_budget = 6
+    // These are the default, and are overriden by the config if uncommented.
+	num_exoplanets = 3
+	away_site_budget = 7
 	id_hud_icons = 'maps/torch/icons/assignment_hud.dmi'


### PR DESCRIPTION
Change log bot still not setup so not bothering much with it.

The recent crashes are caused by the process hanging for too long and dreamdeamon thinking it crashed, it only sometimes happens when multiple plants might have to reroll for more surface materials, or too many turfs/mobs are created in a short time as they all need to be initialized recursively. This is part one of two commits to help the server preform better that I can think of based on some light profiling and debugging. This also reduces startup time, planets take a lot of time to initialize, I've also noted that people said 5 was too many. Though cool. planets would need to be more optimized or generated post general initialization during the 180 seconds character setup or similar.

Edits are enabled if you wish to tinker with the numbers.