### PR TITLE
Bumps prospector skills and expands access a bit

### DIFF
--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -100,7 +100,7 @@
 	                    SKILL_EVA     = SKILL_BASIC)
 
 	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
-	skill_points = 25
+	skill_points = 21
 
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/prospector
 	allowed_branches = list(/datum/mil_branch/civilian)

--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -100,6 +100,7 @@
 	                    SKILL_EVA     = SKILL_BASIC)
 
 	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
+	skill_points = 25
 
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/research/prospector
 	allowed_branches = list(/datum/mil_branch/civilian)
@@ -109,7 +110,7 @@
 		access_mining, access_mining_office, access_mining_station,
 		access_expedition_shuttle, access_guppy, access_hangar,
 		access_guppy_helm, access_solgov_crew, access_eva,
-		access_radio_exp, access_radio_sup
+		access_radio_exp, access_radio_sup, access_cargo, access_cargo_bot, access_maint_tunnels, access_mailsorting
 	)
 
 	minimal_access = list()


### PR DESCRIPTION
Brings the prospector skill points up to 25 due to the fact that they currently have the skill points of a passenger while being expected to fly Garuda, travel to potentially hostile planets, and do the majority of their tasks alone. Also brings their access back to Hestia levels.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->