### PR TITLE
SM alerts to general for low pop

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -302,7 +302,7 @@
 	else
 		alert_msg = null
 	if(alert_msg)
-		GLOB.global_announcer.autosay(alert_msg, "Supermatter Monitor", "Engineering")
+		GLOB.global_announcer.autosay(alert_msg, "Supermatter Monitor", "Common") // Codingale was just "Engineering" 
 		//Public alerts
 		if((damage > emergency_point) && !public_alert)
 			GLOB.global_announcer.autosay("WARNING: SUPERMATTER CRYSTAL DELAMINATION IMMINENT! SAFEROOMS UNBOLTED.", "Supermatter Monitor")


### PR DESCRIPTION
SM alerts to general for low pop, granted only engineers should set it up. This is for those who set it up, and cryo while it's not stable leaving the general populace unaware it's going to explode if no one fixes it, the other announcement it's probably too late to save.